### PR TITLE
errors on log.Printf() to Error Dialogs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 
 *.mif
 goICMCsim
+*.exe

--- a/display/app.go
+++ b/display/app.go
@@ -10,6 +10,7 @@ import (
 	"fyne.io/fyne/v2"
 	"fyne.io/fyne/v2/app"
 	"fyne.io/fyne/v2/container"
+	"fyne.io/fyne/v2/dialog"
 
 	"github.com/lucasgpulcinelli/goICMCsim/display/draw"
 	"github.com/lucasgpulcinelli/goICMCsim/processor"
@@ -85,10 +86,16 @@ func StartSimulatorWindow(codem, charm io.ReadCloser) {
 
 	// if the code or char mapping MIFs were defined, read them
 	if codem != nil {
-		fyneReadMIFCode(codem, nil)
+		var err error = fyneReadMIFCode(codem)
+		if err != nil {
+			dialog.ShowError(err, w)
+		}
 	}
 	if charm != nil {
-		fyneReadMIFChar(charm, nil)
+		var err error = fyneReadMIFChar(charm)
+		if err != nil {
+			dialog.ShowError(err, w)
+		}
 	}
 
 	// refresh the display initially to create a proprer instruction scroll and

--- a/display/menuActions.go
+++ b/display/menuActions.go
@@ -29,7 +29,7 @@ func fyneReadMIFCode(f io.ReadCloser) error {
 
 	data := p.GetData()
 	if len(data) != 1<<16 {
-		return fmt.Errorf("mif is not the right size for code: %d", len(data))
+		return fmt.Errorf("the MIF is not the right size for code: %d", len(data))
 	}
 
 	icmcSimulator.IsRunning = false
@@ -70,8 +70,8 @@ func fyneReadMIFChar(f io.ReadCloser) error {
 	}
 
 	data := p.GetData()
-	if len(data) != 1<<16 {
-		return fmt.Errorf("mif is not the right size for code: %d", len(data))
+	if len(data) != 1<<10 {
+		return fmt.Errorf("the MIF is not the correct size for char: %d", len(data))
 	}
 
 	// set the charmap to draw with

--- a/display/shortcuts.go
+++ b/display/shortcuts.go
@@ -18,7 +18,7 @@ var (
 
 // handleShortcuts runs whem every shortcut is triggered, responsible for
 // calling the associated menu action.
-func handleShortcuts(sh fyne.Shortcut) {
+func handleShortcuts(sh fyne.Shortcut, w fyne.Window) {
 	desktopSh, ok := sh.(*desktop.CustomShortcut)
 	if !ok {
 		fmt.Println("shortcut is not of expected type")
@@ -27,9 +27,9 @@ func handleShortcuts(sh fyne.Shortcut) {
 
 	switch *desktopSh {
 	case shortOneInst:
-		runOneInst()
+		runOneInst(w)
 	case shortUntilHalt:
-		runUntilHalt()
+		runUntilHalt(w)
 	case shortReset:
 		restartCode()
 	case shortStop:
@@ -41,8 +41,8 @@ func handleShortcuts(sh fyne.Shortcut) {
 
 // setupShortcuts adds all shortcuts from the simulator to a window.
 func setupShortcuts(w fyne.Window) {
-	w.Canvas().AddShortcut(&shortOneInst, handleShortcuts)
-	w.Canvas().AddShortcut(&shortUntilHalt, handleShortcuts)
-	w.Canvas().AddShortcut(&shortReset, handleShortcuts)
-	w.Canvas().AddShortcut(&shortStop, handleShortcuts)
+	w.Canvas().AddShortcut(&shortOneInst, func(sh fyne.Shortcut) { handleShortcuts(sh, w) })
+	w.Canvas().AddShortcut(&shortUntilHalt, func(sh fyne.Shortcut) { handleShortcuts(sh, w) })
+	w.Canvas().AddShortcut(&shortReset, func(sh fyne.Shortcut) { handleShortcuts(sh, w) })
+	w.Canvas().AddShortcut(&shortStop, func(sh fyne.Shortcut) { handleShortcuts(sh, w) })
 }

--- a/display/widgets.go
+++ b/display/widgets.go
@@ -71,18 +71,8 @@ func makeMainMenu(w fyne.Window) {
 	// "options" menu toolbar
 	options := fyne.NewMenu("options",
 		fyne.NewMenuItem("reset", restartCode),
-		fyne.NewMenuItem("run until halt", func() {
-			var err error = runUntilHalt()
-			if err != nil {
-				dialog.ShowError(err, w)
-			}
-		}),
-		fyne.NewMenuItem("run one instruction", func ()  {
-			var err error = runOneInst()
-			if err != nil {
-				dialog.ShowError(err, w)
-			}
-		}),
+		fyne.NewMenuItem("run until halt", func() { runUntilHalt(w) }),
+		fyne.NewMenuItem("run one instruction", func () { runOneInst(w) }),
 		fyne.NewMenuItem("stop simulation", stopSim),
 	)
 

--- a/main.go
+++ b/main.go
@@ -25,13 +25,13 @@ func getFiles() (codem, charm io.ReadCloser) {
 	if *initialCode != "" {
 		codem, err = os.Open(*initialCode)
 		if err != nil {
-			log.Printf("error opening %s: %v\n", *initialCode, err.Error())
+			log.Printf("error opening %s: %v\n", *initialCode, err.Error())// TODO: log -> dialog/logFile
 		}
 	}
 	if *initialChar != "" {
 		charm, err = os.Open(*initialChar)
 		if err != nil {
-			log.Printf("error opening %s: %v\n", *initialChar, err.Error())
+			log.Printf("error opening %s: %v\n", *initialChar, err.Error())// TODO: log -> dialog/logFile
 		}
 	}
 	return


### PR DESCRIPTION
Fiz com que os erros que apareciam no terminal fossem mostrados em Dialogs de Error. 
Os únicos que não foram mudados, foram os da função main que são executados antes da criação de uma janela.